### PR TITLE
Sp/new stratification, eddy velocity, and diagnostics

### DIFF
--- a/experiments/experiments.jl
+++ b/experiments/experiments.jl
@@ -9,6 +9,7 @@
 
 # Final configuration to use!!! (twin experiment for the nonhydrostatic one)
 #run_experiment("hydrostatic_twin_simulation"; Q = 50.0, τw = 0.1, Δh = 200, ΔTᶠ = 1.0, a = 1, stop_time = 10days)
+run_experiment("hydrostatic_twin_simulation_1sig"; m₀ = 60, T₀ = 20, Δmᶠ = 10, σ²  = 1, N²T = 2e-4, Q = 40, τw = 0.1, Δh = 200, ΔTᵉ = 0.1, ΔTᶠ = 0, a = 1, Φ = 0.01, stop_time = 40days)
 
-include("initial_turbulence_generator.jl")
-generate_initial_turbulence(;τw  = 0.1, ΔTᵉ = 0.5, output_frequency = 10minutes, stop_time = 10hours)
+#include("initial_turbulence_generator.jl")
+#generate_initial_turbulence(;τw  = 0.1, ΔTᵉ = 0.5, output_frequency = 10minutes, stop_time = 10hours)

--- a/experiments/hydrostatic_experiment.jl
+++ b/experiments/hydrostatic_experiment.jl
@@ -20,7 +20,6 @@ function run_experiment(experiment;
                         Δh  = 250,    # Horizontal resolution [m]
                         Δz  = 2,      # Vertical resolution [m]
                         ΔTᵉ = 0.5,    # Eddy temperature difference
-                        ΔTᶠ = 2.0,    # Meridional temperature difference
                         Φ   = 0.025,  # Barotropic eddy strength
                         a   = 1.2,    # Eddy temperature magnitude
                         Lf  = 0.9,    # Size of temperature front (large numbers correspond to steeper fronts)
@@ -31,7 +30,7 @@ function run_experiment(experiment;
                         background_forcing = true,
                         restart_file = false)
     
-    set_value!(; m₀, T₀, Δmᶠ, N²s, N²T, M²₀, Q, τw, θ, ΔTᵉ, ΔTᶠ, Δz, a, Lf, σ², Φ, Δh)
+    set_value!(; m₀, T₀, Δmᶠ, N²s, N²T, M²₀, Q, τw, θ, ΔTᵉ, Δz, a, Lf, σ², Φ, Δh)
 
 
     @info "Simulation parameters: " parameters

--- a/experiments/hydrostatic_experiment.jl
+++ b/experiments/hydrostatic_experiment.jl
@@ -8,6 +8,12 @@ using JLD2
 architecture = GPU()
 
 function run_experiment(experiment; 
+                        T₀  = 20,
+			            m₀  = 60,
+                        Δmᶠ = 10,
+                        N²s = 5e-7,
+                        N²T = 1e-4,
+                        M²₀ = 5e-7,
                         Q   = 0.0,    # Cooling heat flux in W/m²
                         τw  = 0.0,    # Wind stress in N/m²
                         θ   = 30.0,   # Wind stress angle in degrees (0 correspond to zonal wind stress)
@@ -25,7 +31,8 @@ function run_experiment(experiment;
                         background_forcing = true,
                         restart_file = false)
     
-    set_value!(; Q, τw, θ, ΔTᵉ, ΔTᶠ, Δz, a, Lf, σ², Φ, Δh)
+    set_value!(; m₀, T₀, Δmᶠ, N²s, N²T, M²₀, Q, τw, θ, ΔTᵉ, ΔTᶠ, Δz, a, Lf, σ², Φ, Δh)
+
 
     @info "Simulation parameters: " parameters
 

--- a/experiments/nonhydrostatic_experiment.jl
+++ b/experiments/nonhydrostatic_experiment.jl
@@ -24,7 +24,7 @@ arch = Distributed(GPU(), partition = Partition(proc, proc))
 
 # Grid size
 Δh = 4.8828125 * scaling
-Δz = 1.28 * scaling
+Δz = 1.28 
 
 LESStudySetup.default_experimental_setup!(; Δh, Δz)
                   

--- a/src/Diagnostics/mixed_layer.jl
+++ b/src/Diagnostics/mixed_layer.jl
@@ -9,17 +9,29 @@ const f = Face()
 #####
 
 # b can be temperature (T) or density (ρ)
-@kernel function compute_mld!(h, grid, b, Δb)
+@kernel function compute_mld!(h, grid, b, Δb, surface, stratification)
     i, j = @index(Global, NTuple)
 
     Nz = grid.Nz
     
-    k_start   = Nz - 2
-    z_ij = znode(i, j, k_start, grid, c, c, f)
-    while z_ij > -9.99
-        k_start = k_start-1
+    if surface
+        k_start = Nz - 1
         z_ij = znode(i, j, k_start, grid, c, c, f)
+    else    
+        k_start   = Nz - 2
+        z_ij = znode(i, j, k_start, grid, c, c, f)
+        while z_ij > -9.99
+            k_start = k_start-1
+            z_ij = znode(i, j, k_start, grid, c, c, f)
+        end
     end
+
+    if stratification
+        α = parameters.α
+        g = parameters.g
+        Nh² = 0.0
+    end
+
     b_surface = @inbounds b[i, j, k_start+1]
 
     @unroll for k in k_start : -1 : 1 # scroll from point just below surface
@@ -45,24 +57,48 @@ const f = Face()
         replace_z = (just_below_mixed_layer | inside_mixed_layer) & !inactive_node(i, j, k, grid, c, c, c)
         z_ij = ifelse(replace_z, new_z_ij, z_ij)
         if just_below_mixed_layer 
+            if stratification
+                if zᵏ < z_ij * 1.1
+                    Nh² = α * g * z_ij * 0.1 / Δz⁺ * (Δb⁺ - Δbᵏ)
+                else
+                    b_ij = bᵏ + (z_ij - zᵏ) / Δz⁺ * (Δbᵏ - Δb⁺)
+                    for l in k : -1 : 2
+                        Δzˡ = Δzᶜᶜᶠ(i, j, l, grid)
+                        zˡ = znode(i, j, l-1, grid, c, c, c)
+                        if zˡ < z_ij * 1.1
+                            b⁻ = @inbounds b[i, j, l-1]
+                            bˡ = @inbounds b[i, j, l]
+                            b_new = (z_ij * 1.1 - zˡ) / Δzˡ * (b⁻ - bˡ) + bˡ
+                            Nh² = α * g * (b_new - b_ij) / (0.1 * z_ij)
+                            break
+                        end
+                    end
+                end
+            end
             break
         end
     end
 
     # Note "-" since `h` is supposed to be "depth" rather than "height"
-    @inbounds h[i, j, 1] = - z_ij
+    if stratification
+        @inbounds h[i, j, 1] = Nh²
+    else
+        @inbounds h[i, j, 1] = - z_ij
+    end
 end
 
-struct MixedLayerDepthOperand{B, FT, G}
+struct MixedLayerDepthOperand{B, FT, G, S, N}
     temperature_operation :: B
     mixed_layer_temperature_differential :: FT
     grid :: G
+    surface :: S
+    stratification :: N
 end
 
 Base.summary(op::MixedLayerDepthOperand) = "MixedLayerDepthOperand"
 
-function MixedLayerDepth(grid, tracers; ΔT = 0.2, kw...)
-    operand = MixedLayerDepthOperand(tracers.T, abs(ΔT), grid)
+function MixedLayerDepth(grid, tracers; ΔT = 0.2, surface = false, stratification = false, kw...)
+    operand = MixedLayerDepthOperand(tracers.T, abs(ΔT), grid, surface, stratification)
     return Field{Center, Center, Nothing}(grid; operand, kw...)
 end
 
@@ -72,7 +108,27 @@ function compute!(h::MixedLayerDepthField, time=nothing)
     arch = architecture(h)
     b    = h.operand.temperature_operation
     Δb   = h.operand.mixed_layer_temperature_differential
-    launch!(arch, h.grid, :xy, compute_mld!, h, h.grid, b, Δb)
+    surface = h.operand.surface
+    stratification = h.operand.stratification
+    launch!(arch, h.grid, :xy, compute_mld!, h, h.grid, b, Δb, surface, stratification)
+    fill_halo_regions!(h)
+    return h
+end
+
+function MixedLayerN²(grid, tracers; ΔT = 0.2, surface = false, stratification = true, kw...)
+    operand = MixedLayerDepthOperand(tracers.T, abs(ΔT), grid, surface, stratification)
+    return Field{Center, Center, Nothing}(grid; operand, kw...)
+end
+
+const MixedLayerN²Field = Field{Center, Center, Nothing, <:MixedLayerDepthOperand}
+
+function computeNh!(Nh::MixedLayerN²Field, time=nothing)
+    arch = architecture(Nh)
+    b    = Nh.operand.temperature_operation
+    Δb   = Nh.operand.mixed_layer_temperature_differential
+    surface = Nh.operand.surface
+    stratification = Nh.operand.stratification
+    launch!(arch, h.grid, :xy, compute_mld!, Nh, Nh.grid, b, Δb, surface, stratification)
     fill_halo_regions!(h)
     return h
 end

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -112,8 +112,12 @@ function idealized_setup(arch;
 end
 
 function default_experimental_setup!(; Δh=parameters.Δh, Δz=parameters.Δz)
-    set_value!(; # Forcing
+    set_value!(; 
+               # Grid,
+              Δh = Δh,
+              Δz = Δz,
               Lz = 252,
+               # Forcing
                Q = 40.0,   # Cooling heat flux in W/m²
               τw = 0.1,    # Wind stress in N/m²
                θ = 30.0, # Wind stress angle in degrees (0 correspond to zonal wind stress)

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -111,6 +111,28 @@ function idealized_setup(arch;
     return simulation
 end
 
+function default_experimental_setup!(Δh, Δz)
+    set_value!(; # Forcing
+              Lz = 252,
+               Q = 40.0,   # Cooling heat flux in W/m²
+              τw = 0.1,    # Wind stress in N/m²
+               # Initial condition
+              T₀ = 20,
+              m₀ = 60,
+             Δmᶠ = 10,
+             N²s = 5e-7,
+             N²T = 1e-4,
+             M²₀ = 5e-7,
+             θ   = 30.0, # Wind stress angle in degrees (0 correspond to zonal wind stress)
+             ΔTᵉ = 0.5,  # Eddy temperature difference
+             Φ   = 0.01, # Barotropic eddy strength
+             a   = 1.2,  # Eddy temperature magnitude
+             Lf  = 0.9,  # Size of temperature front (large numbers correspond to steeper fronts)
+             σ²  = 1.0)
+
+    return nothing
+end
+
 function turbulence_generator_setup(arch; 
                                     stop_time = 10hours,
                                     background_forcing = false)

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -86,7 +86,7 @@ function idealized_setup(arch;
     if isforced(model)
         set!(model, v = vᶠ, T = Tᵢ) 
     else
-        set!(model, u = uᵢ, v = vᵢ, T = Tᵢ)
+        set!(model, u = uᵢ, v = vᵢ + vᶠ, T = Tᵢ)
     end
     
     u, v, w = model.velocities

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -111,7 +111,7 @@ function idealized_setup(arch;
     return simulation
 end
 
-function default_experimental_setup!(Δh, Δz)
+function default_experimental_setup!(; Δh=parameters.Δh, Δz=parameters.Δz)
     set_value!(; # Forcing
               Lz = 252,
                Q = 40.0,   # Cooling heat flux in W/m²

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -22,9 +22,9 @@ Finally, a `Simulation` object is created with the model, time step, and stop ti
 """
 function idealized_setup(arch; 
                          stop_time = 100days,
-			 stop_iteration = Inf,
+			             stop_iteration = Inf,
                          hydrostatic_approximation = false,
-                         background_forcing = false)
+                         background_forcing = true) # by default we include the eddies as a background forcing 
     
     # Retrieving the problem constants
     Δh = parameters.Δh 

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -86,7 +86,7 @@ function idealized_setup(arch;
     if isforced(model)
         set!(model, v = vᶠ, T = Tᵢ) 
     else
-        set!(model, u = uᵢ, v = vᵢ + vᶠ, T = Tᵢ)
+        set!(model, u = uᵢ, v = vᵢᶠ, T = Tᵢ)
     end
     
     u, v, w = model.velocities

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -116,20 +116,21 @@ function default_experimental_setup!(Δh, Δz)
               Lz = 252,
                Q = 40.0,   # Cooling heat flux in W/m²
               τw = 0.1,    # Wind stress in N/m²
-               # Initial condition
+               θ = 30.0, # Wind stress angle in degrees (0 correspond to zonal wind stress)
+              # Initial condition - frontal values
+             M²₀ = 5e-7,
               T₀ = 20,
               m₀ = 60,
              Δmᶠ = 10,
              N²s = 5e-7,
-             N²T = 1e-4,
-             M²₀ = 5e-7,
-             θ   = 30.0, # Wind stress angle in degrees (0 correspond to zonal wind stress)
-             ΔTᵉ = 0.5,  # Eddy temperature difference
+             N²T = 2e-4,
+             # Eddy forcing
+             ΔTᵉ = 0.1,  # Eddy temperature difference
              Φ   = 0.01, # Barotropic eddy strength
-             a   = 1.2,  # Eddy temperature magnitude
+             a   = 1.0,  # Eddy temperature magnitude
              Lf  = 0.9,  # Size of temperature front (large numbers correspond to steeper fronts)
              σ²  = 1.0)
-
+    
     return nothing
 end
 

--- a/src/idealized_setup.jl
+++ b/src/idealized_setup.jl
@@ -65,11 +65,10 @@ function idealized_setup(arch;
     
     # # Cooling in the middle of the domain and heating outside?
     # @inline Qtop(x, y, t, p) = - p.Q / p.ρ₀ / p.cₚ * cos(2π * x / p.Lx)
-    @inline Qtop(x, y, t) = Q / ρ₀ / cₚ * (1 - tanh((t - 10days) / 12hours)) / 2
 
     u_top = FluxBoundaryCondition(τw * cosd(θ) / ρ₀)
     v_top = FluxBoundaryCondition(τw * sind(θ) / ρ₀)
-    T_top = FluxBoundaryCondition(Qtop)# / ρ₀ / cₚ) # Positive fluxes at the top are cooling in Oceananigans
+    T_top = FluxBoundaryCondition(Q / ρ₀ / cₚ) # Positive fluxes at the top are cooling in Oceananigans
 
     u_bcs = FieldBoundaryConditions(top = u_top)
     v_bcs = FieldBoundaryConditions(top = v_top)

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -18,6 +18,8 @@ end
     return eddy_tangential_velocity(x, y, z, R, Lf, Le, sin)
 end
 
+@inline minus_sin(θ) = - sin(θ)
+
 @inline minus_cos(θ) = - cos(θ)
 
 @inline function vᵢ(x, y, z)
@@ -29,6 +31,23 @@ end
 end
 
 @inline function eddy_tangential_velocity(x, y, z, R, Lf, Le, trig)
+    if abs(x - 50e3) > 25e3 && abs(y - 50e3) > 25e3
+        x += x < 25e3 ? 50e3 : -50e3
+        y += y < 25e3 ? 50e3 : -50e3
+    elseif x < 25e3
+        x, y = y, 50e3 - x
+        trig = trig == sin ? cos : sin
+    elseif y < 25e3
+        x, y = 50e3 - y, x
+        trig = trig == sin ? minus_cos : minus_sin
+    elseif x > 75e3
+        x, y = y, 150e3 - x
+        trig = trig == sin ? cos : sin
+    elseif y > 75e3
+        x, y = 150e3 - y, x
+        trig = trig == sin ? minus_cos : minus_sin
+    end
+
     # divide into 4 regions
 
     # if x < 50e3 && y < 50e3 # Region 1: warm eddy!
@@ -86,7 +105,7 @@ end
         
         r = sqrt(x′^2 + y′^2)
         ξ = transformR(r, (; R, Le))
-        return warm_eddy(ξ, x, z)
+        return warm_eddy(ξ, x, z) + Tᶠ(x, z)
     
     elseif x < 50e3 && y >= 50e3 # Region 2: cold eddy!
         x′ = x - R
@@ -94,7 +113,7 @@ end
 
         r = sqrt(x′^2 + y′^2)
         ξ = transformR(r, (; R, Le))
-        return cold_eddy(ξ, x, z)
+        return cold_eddy(ξ, x, z) + Tᶠ(x, z)
 
     elseif x >= 50e3 && y < 50e3 # Region 3: cold eddy!
         x′ = x - 3R
@@ -102,7 +121,7 @@ end
 
         r = sqrt(x′^2 + y′^2)
         ξ = transformR(r, (; R, Le))
-        return cold_eddy(ξ, x, z)
+        return cold_eddy(ξ, x, z) + Tᶠ(x, z)
 
     else # Region 4: warm eddy!
         x′ = x - 3R
@@ -110,7 +129,7 @@ end
 
         r = sqrt(x′^2 + y′^2)
         ξ = transformR(r, (; R, Le))
-        return warm_eddy(ξ, x, z)
+        return warm_eddy(ξ, x, z) + Tᶠ(x, z)
     end
 end
 
@@ -198,30 +217,53 @@ end
     Φ  = parameters.Φ
     R  = 25e3
 
-    if x < 50e3 && y < 50e3 # Region 1: warm eddy!
-        x′  = x - R
-        y′  = y - R
-        sng = 1
+    if abs(x - 50e3) > 25e3 && abs(y - 50e3) > 25e3
+        x += x < 25e3 ? 50e3 : -50e3
+        y += y < 25e3 ? 50e3 : -50e3
+    elseif x < 25e3
+        x, y = y, 50e3 - x
 
-    elseif x < 50e3 && y >= 50e3 # Region 2: cold eddy!
-        x′  = x - R
-        y′  = y - 3R
-        sng = - 1
+    elseif y < 25e3
+        x, y = 50e3 - y, x
 
-    elseif x >= 50e3 && y < 50e3 # Region 3: cold eddy!
-        x′  = x - 3R
-        y′  = y - R
-        sng = - 1
+    elseif x > 75e3
+        x, y = y, 150e3 - x
 
-    else # Region 4: warm eddy!
-        x′  = x - 3R
-        y′  = y - 3R
-        sng = 1
+    elseif y > 75e3
+        x, y = 150e3 - y, x
 
     end
 
-    r  = sqrt(x′^2 + y′^2)
-    return sng * η(r, (; R, Lf, σ², Φ))
+    # divide into 4 regions
+
+    #if x < 50e3 && y < 50e3 # Region 1: warm eddy!
+        x′  = x - R
+        y′  = y - R
+        r  = sqrt(x′^2 + y′^2)
+        η1 = η(r, (; R, Lf, σ², Φ))
+
+    #elseif x < 50e3 && y >= 50e3 # Region 2: cold eddy!
+        x′  = x - R
+        y′  = y - 3R
+        r  = sqrt(x′^2 + y′^2)
+        η2 = - η(r, (; R, Lf, σ², Φ))
+
+    #elseif x >= 50e3 && y < 50e3 # Region 3: cold eddy!
+        x′  = x - 3R
+        y′  = y - R
+        r  = sqrt(x′^2 + y′^2)
+        η3 = - η(r, (; R, Lf, σ², Φ))
+
+    #else # Region 4: warm eddy!
+        x′  = x - 3R
+        y′  = y - 3R
+        r  = sqrt(x′^2 + y′^2)
+        η4 = η(r, (; R, Lf, σ², Φ))
+
+    #end
+
+    
+    return η1 + η2 + η3 + η4
 end
 
 @inline function warm_eddy_velocity(ξ, z, r, R, Lf)
@@ -293,5 +335,50 @@ end
         return Tˢ
     else
         return (Tˢ - T₀ + a * ΔT) / (Lz - h)^2 * (Lz + z)^2 + T₀ - a * ΔT
+    end
+end
+
+""" temperature for pure fronts """
+@inline function Tᶠ(x, z)
+
+    Lx  = parameters.Lx
+    Lz  = parameters.Lz
+    Δz  = parameters.Δz
+    Lf  = parameters.Lf * Lx / 45
+    N²s = parameters.N²s
+    N²T = parameters.N²T
+    M²₀ = parameters.M²₀
+    h₀  = parameters.m₀
+    Δh  = parameters.Δmᶠ
+    α   = parameters.α
+    g   = parameters.g
+    
+    ΔTₒ = M²₀ * Lf / (α * g)
+    ΓT = 0.5 / (α * g) * ((N²s+0.1*N²T)*z+Δh*((N²s-N²T)*log(cosh((z+h₀)/Δh)/cosh(h₀/Δh))+0.9*N²T*log(cosh((z+1.5h₀)/Δh)/cosh(1.5h₀/Δh))))
+    if z <= - (Lz - Δz)
+        return ΓT
+    elseif x <= Lx/2
+        return ΔTₒ * 0.25 * (1-tanh(x/(0.5*Lf))+tanh((x-Lx/2)/(0.5*Lf)))*(tanh((z+h₀)/Δh)+1) + ΓT
+    else
+        return ΔTₒ * 0.25 * (tanh((x-Lx/2)/(0.5*Lf))-tanh((x-Lx)/(0.5*Lf))-1)*(tanh((z+h₀)/Δh)+1) + ΓT
+    end
+end
+
+""" velocity for pure fronts """
+@inline function vᶠ(x, y, z)
+
+    Lx  = parameters.Lx
+    Lf  = parameters.Lf * Lx / 45
+    M²₀ = parameters.M²₀
+    h₀  = parameters.m₀
+    Δh  = parameters.Δmᶠ
+    f   = parameters.f
+
+    if z <= -h₀
+        return 0.0
+    elseif x <= Lx/2
+        return M²₀ * 0.5 / f * (sech((x-Lx/2)/(0.5*Lf))^2-sech(x/(0.5*Lf))^2)*(Δh*log(cosh((z+h₀)/Δh))+z+h₀) 
+    else
+        return M²₀ * 0.5 / f * (sech((x-Lx/2)/(0.5*Lf))^2-sech((x-Lx)/(0.5*Lf))^2)*(Δh*log(cosh((z+h₀)/Δh))+z+h₀)
     end
 end

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -49,45 +49,45 @@ end
 
     # divide into 4 regions
 
-    # if x < 50e3 && y < 50e3 # Region 1: warm eddy!
-        x′ = x - R
-        y′ = y - R
-        
-        r  = sqrt(x′^2 + y′^2)
-        ξ  = transformR(r, (; R, Le))
-        uθ = warm_eddy_velocity(ξ, z, r, R, Lf)
-        θ  = atan(y′, x′)
-        u1 = trig(θ) * uθ
+    # Region 1: warm eddy! (x < 50e3 && y < 50e3)
+    x′ = x - R
+    y′ = y - R
     
-    # elseif x < 50e3 && y >= 50e3 # Region 2: cold eddy!
-        x′ = x - R
-        y′ = y - 3R
+    r  = sqrt(x′^2 + y′^2)
+    ξ  = transformR(r, (; R, Le))
+    uθ = warm_eddy_velocity(ξ, z, r, R, Lf)
+    θ  = atan(y′, x′)
+    u1 = trig(θ) * uθ
+    
+    # Region 2: cold eddy! (x < 50e3 && y >= 50e3)
+    x′ = x - R
+    y′ = y - 3R
 
-        r  = sqrt(x′^2 + y′^2)
-        ξ  = transformR(r, (; R, Le))
-        uθ = cold_eddy_velocity(ξ, z, r, R, Lf)
-        θ  = atan(y′, x′)
-        u2 = trig(θ) * uθ
+    r  = sqrt(x′^2 + y′^2)
+    ξ  = transformR(r, (; R, Le))
+    uθ = cold_eddy_velocity(ξ, z, r, R, Lf)
+    θ  = atan(y′, x′)
+    u2 = trig(θ) * uθ
 
-    # elseif x >= 50e3 && y < 50e3 # Region 3: cold eddy!
-        x′ = x - 3R
-        y′ = y - R
+    # Region 3: cold eddy! (x >= 50e3 && y < 50e3)
+    x′ = x - 3R
+    y′ = y - R
 
-        r  = sqrt(x′^2 + y′^2)
-        ξ  = transformR(r, (; R, Le))
-        uθ = cold_eddy_velocity(ξ, z, r, R, Lf)
-        θ  = atan(y′, x′)
-        u3 = trig(θ) * uθ
+    r  = sqrt(x′^2 + y′^2)
+    ξ  = transformR(r, (; R, Le))
+    uθ = cold_eddy_velocity(ξ, z, r, R, Lf)
+    θ  = atan(y′, x′)
+    u3 = trig(θ) * uθ
 
-    # else # Region 4: warm eddy!
-        x′ = x - 3R
-        y′ = y - 3R
+    # Region 4: warm eddy! 
+    x′ = x - 3R
+    y′ = y - 3R
 
-        r = sqrt(x′^2 + y′^2)
-        ξ = transformR(r, (; R, Le))
-        uθ = warm_eddy_velocity(ξ, z, r, R, Lf)
-        θ  = atan(y′, x′)
-        u4 = trig(θ) * uθ
+    r = sqrt(x′^2 + y′^2)
+    ξ = transformR(r, (; R, Le))
+    uθ = warm_eddy_velocity(ξ, z, r, R, Lf)
+    θ  = atan(y′, x′)
+    u4 = trig(θ) * uθ
     
     return u1 + u2 + u3 + u4
 end

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -133,15 +133,7 @@ end
     end
 end
 
-@inline function T̅(χ) 
-    ΔT = parameters.ΔTᶠ
-    T₀ = parameters.T₀
-    
-    T₃ = 1 - (π - χ - sin(π - χ) * cos(π - χ)) / π
-    Tₘ = Int(χ > 3.1415926535897) + Int(0 < χ < 3.1415926535897) * T₃
-
-    return ΔT * Tₘ + T₀
-end
+@inline T̅(χ) = parameters.T₀
 
 # Mixed layer depth profile
 @inline function h̅⁺(ξ)

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -382,3 +382,8 @@ end
         return M²₀ * 0.5 / f * (sech((x-Lx/2)/(0.5*Lf))^2-sech((x-Lx)/(0.5*Lf))^2)*(Δh*log(cosh((z+h₀)/Δh))+z+h₀)
     end
 end
+
+""" velocity for eddies and fronts """
+@inline function vᵢᶠ(x, y, z)
+    return vᵢ(x, y, z) + vᶠ(x, y, z)
+end

--- a/src/initial_conditions.jl
+++ b/src/initial_conditions.jl
@@ -19,7 +19,6 @@ end
 end
 
 @inline minus_sin(θ) = - sin(θ)
-
 @inline minus_cos(θ) = - cos(θ)
 
 @inline function vᵢ(x, y, z)

--- a/src/model_setup.jl
+++ b/src/model_setup.jl
@@ -1,5 +1,5 @@
 using Oceananigans.Utils
-using Oceananigans.Grids: node
+using Oceananigans.Grids: node, architecture
 using Oceananigans.BoundaryConditions
 using Oceananigans.Advection: TracerAdvection
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEMixingLength, CATKEVerticalDiffusivity

--- a/src/model_setup.jl
+++ b/src/model_setup.jl
@@ -32,7 +32,7 @@ function model_settings(model_type, grid; background_forcing = false)
         set!(u_background, uᵢ)
         fill_halo_regions!(u_background)
 
-        launch!(architecture(grid), grid, :xz, _compute_v_from_continuity, v_background, grid, u_background)
+        launch!(architecture(grid), grid, :xz, _compute_v_from_continuity!, v_background, grid, u_background)
         fill_halo_regions!(v_background)
 
         advection = ForcedAdvection(; scheme = advection,

--- a/src/model_setup.jl
+++ b/src/model_setup.jl
@@ -23,7 +23,7 @@ end
 
 function model_settings(model_type, grid; background_forcing = false)
     
-    advection = WENO(; order = 7)
+    advection = WENO(; order = 9)
 
     if background_forcing
         u_background = XFaceField(grid)

--- a/src/model_setup.jl
+++ b/src/model_setup.jl
@@ -1,4 +1,5 @@
 using Oceananigans.Grids: node
+using Oceananigans.BoundaryConditions
 using Oceananigans.Advection: TracerAdvection
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEMixingLength, CATKEVerticalDiffusivity
 using Statistics: mean
@@ -19,6 +20,9 @@ function model_settings(model_type, grid; background_forcing = false)
 
         set!(u_background, uᵢ)
         set!(v_background, vᵢ)
+
+        fill_halo_regions!(u_background)
+        fill_halo_regions!(v_background)
 
         advection = ForcedAdvection(; scheme = advection,
                                       u_background,

--- a/src/model_setup.jl
+++ b/src/model_setup.jl
@@ -1,14 +1,25 @@
+using Oceananigans.Utils
 using Oceananigans.Grids: node
 using Oceananigans.BoundaryConditions
 using Oceananigans.Advection: TracerAdvection
 using Oceananigans.TurbulenceClosures.TKEBasedVerticalDiffusivities: CATKEMixingLength, CATKEVerticalDiffusivity
 using Statistics: mean
+using KernelAbstractions: @index, @kernel
 
 model_type(::Val{true})  = HydrostaticFreeSurfaceModel
 model_type(::Val{false}) = NonhydrostaticModel
 
 isforced(model::HydrostaticFreeSurfaceModel) = model.advection.momentum isa ForcedAdvection
 isforced(model::NonhydrostaticModel) = model.advection isa ForcedAdvection
+
+@kernel function _compute_v_from_continuity!(v, grid, u)
+    i, k = @index(Global, NTuple)
+
+    @inbounds v[i, 1, k] = 0
+    for j in 2:size(grid, 2) + 1
+        @inbounds v[i, j, k] = v[i, j-1, k] - Δyᶜᶜᶜ(i, j-1, k, grid) * ∂xᶜᶜᶜ(i, j-1, k, grid, u)
+    end
+end
 
 function model_settings(model_type, grid; background_forcing = false)
     
@@ -19,9 +30,9 @@ function model_settings(model_type, grid; background_forcing = false)
         v_background = YFaceField(grid)
 
         set!(u_background, uᵢ)
-        set!(v_background, vᵢ)
-
         fill_halo_regions!(u_background)
+
+        launch!(architecture(grid), grid, :xz, _compute_v_from_continuity, v_background, grid, u_background)
         fill_halo_regions!(v_background)
 
         advection = ForcedAdvection(; scheme = advection,

--- a/src/model_setup.jl
+++ b/src/model_setup.jl
@@ -45,6 +45,7 @@ function model_settings(model_type, grid; background_forcing = false)
     else
         return (; tracers = :T, 
                   timestepper = :RungeKutta3,
+                  hydrostatic_pressure_anomaly = CenterField(grid),
                   advection)
     end
 end

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -25,6 +25,9 @@ A mutable struct representing the constants used in the LES study setup.
 - `Jᵀ::Float64`: Heat flux at the top.
 """
 @kwdef mutable struct ProblemConstants
+    N²s :: Float64 = 5e-7
+    N²T :: Float64 = 1e-4
+    M²₀ :: Float64 = 5e-7
     ΔTᵉ :: Float64 = 0.5
     ΔTᶠ :: Float64 = 2.0
     a   :: Float64 = 1.2
@@ -33,6 +36,7 @@ A mutable struct representing the constants used in the LES study setup.
     cp  :: Float64 = 3995
     Δh  :: Float64 = 1kilometers
     m₀  :: Float64 = 50
+    Δmᶠ :: Float64 = 10
     Δm  :: Float64 = 30
     Δz  :: Float64 = 4meters
     Lx  :: Float64 = 100kilometers
@@ -51,13 +55,17 @@ A mutable struct representing the constants used in the LES study setup.
 end
 
 Base.show(io::IO, c::ProblemConstants) =
-    print(io, "├── eddy temperature difference:  ΔTᵉ = ", c.ΔTᵉ, "\n",
+    print(io, "├── surface stratification:       N²s = ", c.N²s, "\n",
+              "├── pycnocline stratification:    N²T = ", c.N²T, "\n",
+              "├── frontal density gradient:     M²₀ = ", c.M²₀, "\n",
+              "├── eddy temperature difference:  ΔTᵉ = ", c.ΔTᵉ, "\n",
               "├── front temperature difference: ΔTᶠ = ", c.ΔTᶠ, "\n",
               "├── eddy temperature amplitude:     a = ", c.a, "\n",
               "├── reference density:             ρ₀ = ", c.ρ₀, "\n",
               "├── surface temperature:           T₀ = ", c.T₀, "\n",
               "├── heat capacity:                 cp = ", c.cp, "\n",
               "├── initial mixed layer            m₀ = ", c.m₀, "\n",
+              "├── frontal mld difference        Δmᶠ = ", c.Δmᶠ, "\n",
               "├── mld difference                 Δm = ", c.Δm, "\n",
               "├── horizontal spacing:            Δh = ", c.Δh, "\n",
               "├── vertical spacing:              Δz = ", c.Δz, "\n",
@@ -102,14 +110,18 @@ function set!(c::ProblemConstants; kwargs...)
 end
 
 struct GPUProblemConstants
+   N²s :: Float64
+   N²T :: Float64
+   M²₀ :: Float64
    ΔTᵉ :: Float64
    ΔTᶠ :: Float64
      a :: Float64
     ρ₀ :: Float64 
     T₀ :: Float64 
     cp :: Float64 
-     H :: Float64 
-    ΔH :: Float64 
+     m :: Float64 
+   Δmᶠ :: Float64 
+    Δm :: Float64 
     Δh :: Float64 
     Δz :: Float64 
     Lx :: Float64 

--- a/src/parameters.jl
+++ b/src/parameters.jl
@@ -29,7 +29,6 @@ A mutable struct representing the constants used in the LES study setup.
     N²T :: Float64 = 1e-4
     M²₀ :: Float64 = 5e-7
     ΔTᵉ :: Float64 = 0.5
-    ΔTᶠ :: Float64 = 2.0
     a   :: Float64 = 1.2
     ρ₀  :: Float64 = 1020
     T₀  :: Float64 = 5
@@ -59,7 +58,6 @@ Base.show(io::IO, c::ProblemConstants) =
               "├── pycnocline stratification:    N²T = ", c.N²T, "\n",
               "├── frontal density gradient:     M²₀ = ", c.M²₀, "\n",
               "├── eddy temperature difference:  ΔTᵉ = ", c.ΔTᵉ, "\n",
-              "├── front temperature difference: ΔTᶠ = ", c.ΔTᶠ, "\n",
               "├── eddy temperature amplitude:     a = ", c.a, "\n",
               "├── reference density:             ρ₀ = ", c.ρ₀, "\n",
               "├── surface temperature:           T₀ = ", c.T₀, "\n",
@@ -109,36 +107,4 @@ function set!(c::ProblemConstants; kwargs...)
     return nothing
 end
 
-struct GPUProblemConstants
-   N²s :: Float64
-   N²T :: Float64
-   M²₀ :: Float64
-   ΔTᵉ :: Float64
-   ΔTᶠ :: Float64
-     a :: Float64
-    ρ₀ :: Float64 
-    T₀ :: Float64 
-    cp :: Float64 
-     m :: Float64 
-   Δmᶠ :: Float64 
-    Δm :: Float64 
-    Δh :: Float64 
-    Δz :: Float64 
-    Lx :: Float64 
-    Ly :: Float64 
-    Lz :: Float64 
-     f :: Float64 
-    τw :: Float64 
-     θ :: Float64 
-     Q :: Float64 
-     α :: Float64 
-    Lf :: Float64 
-    σ² :: Float64 
-     g :: Float64 
-end
-
-Adapt.adapt_structure(to, p::ProblemConstants) = 
-    GPUProblemConstants(Tuple(getproperty(p, name) for name in propertynames(p))...)
-
-gpuify(p::ProblemConstants)  = GPUProblemConstants(Tuple(getproperty(p, name) for name in propertynames(p))...)
 tuplify(p::ProblemConstants) = NamedTuple{propertynames(parameters)}(Tuple(getproperty(parameters, prop) for prop in propertynames(parameters)))


### PR DESCRIPTION
A three-layer stratification is added to represent a weakly-stratified mixed layer, a strongly-stratified thermocline, and a moderately stratified deeper layer. The front fields are separated from the eddy fields, and the thermal-wind velocity at the fronts are added as an initial condition. Once we separate the fronts and eddies, the eddy fields have displacement and rotational symmetries between the Lx/2-by-Ly/2 subdomain in the center and other boundary domains. And these symmetries are used to set the eddy velocities and surface levels such that the periodic boundary conditions are satisfied. The cooling is updated to stop after 10 days. And other minor edits are included for some diagnostics. 